### PR TITLE
[12/06/25-1] Suporte envio PDF's

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-slim AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tesseract-ocr tesseract-ocr-por libvips \
+    tesseract-ocr tesseract-ocr-por libvips poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -12,7 +12,7 @@ COPY . .
 
 FROM node:22-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tesseract-ocr tesseract-ocr-por libvips \
+    tesseract-ocr tesseract-ocr-por libvips poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,13 @@
+export default [
+  {
+    files: ["**/*.js"],
+    ignores: ["node_modules/**"],
+    languageOptions: {
+      sourceType: "module",
+      ecmaVersion: "latest",
+    },
+    plugins: {
+    },
+    rules: {},
+  },
+];

--- a/backend/src/controllers/ocrController.js
+++ b/backend/src/controllers/ocrController.js
@@ -1,13 +1,24 @@
 import ocrService from '../services/ocrService.js';
+import pdfOcrService from '../services/pdfOcrService.js';
 import db from '../db/index.js';
 import fs from 'fs/promises';
 
 export default async (req, res, next) => {
   if (!req.file) return res.status(400).json({ error: 'Imagem ausente' });
   try {
-    const text = await ocrService(req.file.path);
-    await db('results').insert({ filename: req.file.filename, text });
-    res.json({ text });
+    let result;
+    if (req.file.mimetype === 'application/pdf') {
+      result = await pdfOcrService(req.file.path);
+      await db('results').insert({
+        filename: req.file.filename,
+        text: result.pages.map(p => p.text).join('\n\n')
+      });
+      res.json(result);
+    } else {
+      const text = await ocrService(req.file.path);
+      await db('results').insert({ filename: req.file.filename, text });
+      res.json({ text });
+    }
   } catch (e) {
     next(e);
   } finally {

--- a/backend/src/routes/ocr.js
+++ b/backend/src/routes/ocr.js
@@ -9,12 +9,16 @@ const storage = multer.diskStorage({
   destination: '/tmp/uploads',
   filename: (_, file, cb) => cb(null, uuid() + path.extname(file.originalname))
 });
+
 const upload = multer({
   storage,
-  limits: { fileSize: 5 * 1024 * 1024 },
-  fileFilter: (_, file, cb) =>
-    /image\/(png|jpe?g|webp)/.test(file.mimetype)
-      ? cb(null, true)
-      : cb(new Error('Formato não suportado'))
+  limits: { fileSize: 25 * 1024 * 1024 },
+  fileFilter: (_, file, cb) => {
+    const ok =
+      /image\/(png|jpe?g|webp)/.test(file.mimetype) ||
+      file.mimetype === 'application/pdf';
+    ok ? cb(null, true) : cb(new Error('Formato não suportado'));
+  }
 });
-export default router.post('/', upload.single('image'), ocrController);
+
+export default router.post('/', upload.single('file'), ocrController);

--- a/backend/src/services/pdfOcrService.js
+++ b/backend/src/services/pdfOcrService.js
@@ -1,0 +1,37 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import ocrService from './ocrService.js';
+
+const execFileAsync = promisify(execFile);
+
+async function getTotalPages(pdfPath) {
+  const { stdout } = await execFileAsync('pdfinfo', [pdfPath]);
+  const match = stdout.match(/Pages:\s+(\d+)/i);
+  return match ? Number(match[1]) : 1;
+}
+
+export default async function pdfOcrService(pdfPath, pages = []) {
+  const totalPages = await getTotalPages(pdfPath);
+  const targets = pages.length ? pages : Array.from({ length: totalPages }, (_, i) => i + 1);
+  const results = [];
+
+  for (const n of targets) {
+    if (n < 1 || n > totalPages) {
+      const err = new Error('Página fora do intervalo');
+      err.status = 400;
+      throw err;
+    }
+    const base = path.join(os.tmpdir(), `${path.basename(pdfPath, path.extname(pdfPath))}-${n}`);
+    const png = `${base}.png`;
+    await execFileAsync('pdftoppm', ['-png', '-f', String(n), '-singlefile', pdfPath, base]);
+    const text = await ocrService(png);
+    results.push({ n, text });
+    await fs.unlink(png).catch(() => {});
+  }
+
+  return { totalPages, pages: results };
+}
+


### PR DESCRIPTION
## Sumário
- Permite arquivos PDF usando serviço /ocr
- Converte PDF em imagens para executar serviço OCR
- Biblioteca `poppler-utils` para utilizar ferramenta pdfinfo e pdftoppm

## Teste
- npm run lint
- npm test -- --passWithNoTests
